### PR TITLE
Supervisor info does not belong to sick notification

### DIFF
--- a/templates/notifications/sick_day_work_log_created.html.twig
+++ b/templates/notifications/sick_day_work_log_created.html.twig
@@ -13,9 +13,6 @@
         <p>
             <strong>Datum: </strong>{{ workLog.date | date('d.m.Y') }}<br>
             <strong>Betrifft: </strong>{{ workLog.workMonth.user.firstName }} {{ workLog.workMonth.user.lastName }}<br>
-            {% if supervisor is not null %}
-                <strong>Gewährt durch: </strong>{{ supervisor.firstName }} {{ supervisor.lastName }}<br>
-            {% endif %}
             <strong>Variante: </strong>
             {% if workLog.variant == 'SICK_CHILD' %}Kind krank{% endif %}
             {% if workLog.variant == 'WITH_NOTE' %}Mit Krankenschein{% endif %}


### PR DESCRIPTION
Removal of supervisor because of two reasons:
- it says supervisor approved the sick notification which is not true (mail is sent without approval)
- supervisors generally don't need to approve sick notes